### PR TITLE
remove plugins_url() for twitter since already a URL and use proper deps arg for wp_enqueue_script

### DIFF
--- a/wp-hyperaudio/hyperaudio.php
+++ b/wp-hyperaudio/hyperaudio.php
@@ -226,13 +226,13 @@ $o .= '  </script>
 function hyperaudio_init()
 {
   if (!is_admin()) {
-    wp_enqueue_script('velocity', plugins_url('/js/velocity.js', __FILE__), false, '1.0.0', false);
-    wp_enqueue_script('hyperaudio-lite', plugins_url('/js/hyperaudio-lite.js', __FILE__), false, '1.0.0', false);
-    wp_enqueue_script('caption', plugins_url('/js/caption.js', __FILE__), false, '1.0.0', false);
-    wp_enqueue_script('share-this', plugins_url('/js/share-this.js', __FILE__), false, '1.0.0', false);
-    wp_enqueue_script('share-this-twitter', plugins_url('/js/share-this-twitter.js', __FILE__), false, '1.0.0', false);
-    wp_enqueue_script('share-this-clipboard', plugins_url('/js/share-this-clipboard.js', __FILE__), false, '1.0.0', false);
-    wp_enqueue_script('twitter-widget', plugins_url('https://platform.twitter.com/widgets.js', __FILE__), false, '1.0.0', false);
+    wp_enqueue_script('velocity', plugins_url('/js/velocity.js', __FILE__), array(), '1.0.0', false);
+    wp_enqueue_script('hyperaudio-lite', plugins_url('/js/hyperaudio-lite.js', __FILE__), array(), '1.0.0', false);
+    wp_enqueue_script('caption', plugins_url('/js/caption.js', __FILE__), array(), '1.0.0', false);
+    wp_enqueue_script('share-this', plugins_url('/js/share-this.js', __FILE__), array(), '1.0.0', false);
+    wp_enqueue_script('share-this-twitter', plugins_url('/js/share-this-twitter.js', __FILE__), array(), '1.0.0', false);
+    wp_enqueue_script('share-this-clipboard', plugins_url('/js/share-this-clipboard.js', __FILE__), array(), '1.0.0', false);
+    wp_enqueue_script('twitter-widget', 'https://platform.twitter.com/widgets.js', array(), '1.0.0', false);
   }
 }
 


### PR DESCRIPTION
Don't know if you want a specific version of the twitter widgets.js. So, the version could possibly be blank or set to something other than 1.0.0.